### PR TITLE
Multi-targeting for .NET Core support

### DIFF
--- a/src/Castle.Core.AsyncInterceptor/AsyncDeterminationInterceptor.cs
+++ b/src/Castle.Core.AsyncInterceptor/AsyncDeterminationInterceptor.cs
@@ -75,7 +75,7 @@ namespace Castle.DynamicProxy
                 return MethodType.Synchronous;
 
             // The return type is a task of some sort, so assume it's asynchronous
-            return returnType.IsGenericType ? MethodType.AsyncFunction : MethodType.AsyncAction;
+            return returnType.GetTypeInfo().IsGenericType ? MethodType.AsyncFunction : MethodType.AsyncAction;
         }
 
         /// <summary>
@@ -94,7 +94,7 @@ namespace Castle.DynamicProxy
         {
             Type taskReturnType = returnType.GetGenericArguments()[0];
             MethodInfo method = HandleAsyncMethodInfo.MakeGenericMethod(taskReturnType);
-            return (GenericAsyncHandler)Delegate.CreateDelegate(typeof(GenericAsyncHandler), method);
+            return (GenericAsyncHandler)method.CreateDelegate(typeof(GenericAsyncHandler));
         }
 
         /// <summary>

--- a/src/Castle.Core.AsyncInterceptor/project.json
+++ b/src/Castle.Core.AsyncInterceptor/project.json
@@ -9,12 +9,21 @@
     "Microsoft.CodeAnalysis.FxCopAnalyzers": {
       "version": "1.2.0-beta2",
       "type": "build"
-    },
-    "Castle.Core": "3.1.0"
+    }
   },
 
   "frameworks": {
-    "net45": {}
+    "net45": {
+      "dependencies": {
+        "Castle.Core": "3.1.0"
+      }
+    },
+    "netstandard1.3": {
+      "dependencies": {
+        "Castle.Core": "4.0.0-beta002",
+        "System.Collections.Concurrent": "4.0.12"
+      }
+    }
   },
 
   "buildOptions": {

--- a/test/Castle.Core.AsyncInterceptor.Tests/project.json
+++ b/test/Castle.Core.AsyncInterceptor.Tests/project.json
@@ -4,11 +4,11 @@
   "testRunner": "xunit",
 
   "dependencies": {
-    "AutoFixture": "3.48.0",
-    "AutoFixture.AutoMoq": "3.48.0",
+    "AutoFixture": "3.50.2",
+    "AutoFixture.AutoMoq": "3.50.2",
     "Castle.Core.AsyncInterceptor": "1.0.0-*",
     "dotnet-test-xunit": "2.2.0-preview2-build1029",
-    "Moq": "4.5.10",
+    "Moq": "4.5.28",
     "xunit": "2.2.0-beta2-build3300"
   },
 

--- a/test/packages.config
+++ b/test/packages.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="coveralls.io" version="1.3.4" />
   <package id="OpenCover" version="4.6.519" />
-  <package id="ReportGenerator" version="2.4.5.0" />
+  <package id="ReportGenerator" version="2.5.1" />
   <package id="xunit.runner.console" version="2.1.0" />
 </packages>


### PR DESCRIPTION
The generated package now supports [.NET Standard 1.3](https://docs.microsoft.com/en-us/dotnet/articles/standard/library ".NET Standard Library") as well as .NET 4.5