### PR TITLE
Provide return value when signalling CompletedInvocation

### DIFF
--- a/RestorePackages.cmd
+++ b/RestorePackages.cmd
@@ -5,7 +5,7 @@
 @IF NOT EXIST %CACHED_NUGET% (
 	echo Downloading latest version of NuGet.exe...
 	IF NOT EXIST "%USERPROFILE%\.nuget" md "%USERPROFILE%\.nuget"
-	powershell -NoProfile -ExecutionPolicy unrestricted -Command "$ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest 'https://dist.nuget.org/win-x86-commandline/v4.0.0/nuget.exe' -OutFile %CACHED_NUGET:"='%"
+	powershell -NoProfile -ExecutionPolicy unrestricted -Command "$ProgressPreference = 'SilentlyContinue'; Invoke-WebRequest 'https://dist.nuget.org/win-x86-commandline/latest/nuget.exe' -OutFile %CACHED_NUGET:"='%"
 )
 
 @echo %CACHED_NUGET% restore castle.core.asyncinterceptor.sln

--- a/src/Castle.Core.AsyncInterceptor/Castle.Core.AsyncInterceptor.csproj
+++ b/src/Castle.Core.AsyncInterceptor/Castle.Core.AsyncInterceptor.csproj
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Castle.Core" Version="4.0.0" />
+    <PackageReference Include="Castle.Core" Version="4.1.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/Castle.Core.AsyncInterceptor/Castle.Core.AsyncInterceptor.csproj
+++ b/src/Castle.Core.AsyncInterceptor/Castle.Core.AsyncInterceptor.csproj
@@ -9,7 +9,7 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <Authors>James Skimming</Authors>
     <Description>AsyncInterceptor is an extension to Castle DynamicProxy to simplify the development of interceptors for asynchronous methods.</Description>
-    <Copyright>Copyright © James Skimming 2016</Copyright>
+    <Copyright>Copyright © 2016 James Skimming</Copyright>
     <PackageLicenseUrl>https://github.com/JSkimming/Castle.Core.AsyncInterceptor/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/JSkimming/Castle.Core.AsyncInterceptor</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/castleproject/Core/v4.0.0/docs/images/castle-logo.png</PackageIconUrl>
@@ -28,15 +28,7 @@
 
   <ItemGroup>
     <PackageReference Include="Castle.Core" Version="4.0.0" />
-  </ItemGroup>
-
-  <!--
-  Disable StyleCop as it breaks dotnet build compilation, and therefore breaks the travis CI build
-  -->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'dontbother' ">
-    <PackageReference Include="StyleCop.Analyzers" Version="1.0.0">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Castle.Core.AsyncInterceptor/stylecop.ruleset
+++ b/src/Castle.Core.AsyncInterceptor/stylecop.ruleset
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="Rules for StyleCop.Analyzers" Description="Code analysis rules for Castle.Core.AsyncInterceptor." ToolsVersion="14.0">
+<RuleSet Name="Rules for StyleCop.Analyzers" Description="Code analysis rules." ToolsVersion="14.0">
   <Include Path="minimumrecommendedrules.ruleset" Action="Default" />
   <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
     <Rule Id="SA1101" Action="None" />

--- a/test/Castle.Core.AsyncInterceptor.Tests/Castle.Core.AsyncInterceptor.Tests.csproj
+++ b/test/Castle.Core.AsyncInterceptor.Tests/Castle.Core.AsyncInterceptor.Tests.csproj
@@ -35,8 +35,8 @@
       <HintPath>..\..\packages\Castle.Core.4.1.0\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Moq, Version=4.7.8.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Moq.4.7.8\lib\net45\Moq.dll</HintPath>
+    <Reference Include="Moq, Version=4.7.63.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Moq.4.7.63\lib\net45\Moq.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/test/Castle.Core.AsyncInterceptor.Tests/Castle.Core.AsyncInterceptor.Tests.csproj
+++ b/test/Castle.Core.AsyncInterceptor.Tests/Castle.Core.AsyncInterceptor.Tests.csproj
@@ -62,7 +62,9 @@
     <Compile Include="InterfaceProxies\TestAsyncInterceptor.cs" />
     <Compile Include="InterfaceProxies\TestAsyncTimingInterceptor.cs" />
     <Compile Include="InterfaceProxies\TestProcessingAsyncInterceptor.cs" />
+    <Compile Include="InterfaceProxies\TestProcessingReturnValueAsyncInterceptor.cs" />
     <Compile Include="ProcessingAsyncInterceptorShould.cs" />
+    <Compile Include="ProcessingAsyncInterceptorWithReturnValueShould.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ProxyGeneratorExtensionsShould.cs" />
   </ItemGroup>

--- a/test/Castle.Core.AsyncInterceptor.Tests/Castle.Core.AsyncInterceptor.Tests.csproj
+++ b/test/Castle.Core.AsyncInterceptor.Tests/Castle.Core.AsyncInterceptor.Tests.csproj
@@ -31,8 +31,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Castle.Core.4.0.0\lib\net45\Castle.Core.dll</HintPath>
+    <Reference Include="Castle.Core, Version=4.1.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Castle.Core.4.1.0\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Moq, Version=4.7.8.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">

--- a/test/Castle.Core.AsyncInterceptor.Tests/InterfaceProxies/TestProcessingReturnValueAsyncInterceptor.cs
+++ b/test/Castle.Core.AsyncInterceptor.Tests/InterfaceProxies/TestProcessingReturnValueAsyncInterceptor.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) 2016 James Skimming. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace Castle.DynamicProxy.InterfaceProxies
+{
+    using System;
+    using System.Collections.Generic;
+
+    public class TestProcessingReturnValueAsyncInterceptor : ProcessingAsyncInterceptor<object>
+    {
+        private readonly ICollection<string> _log;
+
+        public TestProcessingReturnValueAsyncInterceptor(List<string> log)
+        {
+            _log = log ?? throw new ArgumentNullException(nameof(log));
+        }
+
+        protected override object StartingInvocation(IInvocation invocation)
+        {
+            base.StartingInvocation(invocation);
+            _log.Add($"{invocation.Method.Name}:StartingInvocation");
+            return null;
+        }
+
+        protected override void CompletedInvocation(IInvocation invocation, object state, object returnValue)
+        {
+            base.CompletedInvocation(invocation, state, returnValue);
+            _log.Add($"{invocation.Method.Name}:CompletedInvocation:{returnValue ?? "(no return value)"}");
+        }
+    }
+}

--- a/test/Castle.Core.AsyncInterceptor.Tests/ProcessingAsyncInterceptorWithReturnValueShould.cs
+++ b/test/Castle.Core.AsyncInterceptor.Tests/ProcessingAsyncInterceptorWithReturnValueShould.cs
@@ -1,0 +1,189 @@
+﻿// Copyright (c) 2016 James Skimming. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace Castle.DynamicProxy
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Castle.DynamicProxy.InterfaceProxies;
+    using Xunit;
+
+    public class WhenProcessingSynchronousVoidMethodsWithTheReturnValue
+    {
+        private const string MethodName = nameof(IInterfaceToProxy.SynchronousVoidMethod);
+        private readonly List<string> _log = new List<string>();
+        private readonly TestProcessingReturnValueAsyncInterceptor _interceptor;
+        private readonly IInterfaceToProxy _proxy;
+
+        public WhenProcessingSynchronousVoidMethodsWithTheReturnValue()
+        {
+            _interceptor = new TestProcessingReturnValueAsyncInterceptor(_log);
+            _proxy = ProxyGen.CreateProxy(_log, _interceptor);
+        }
+
+        [Fact]
+        public void ShouldLog4Entries()
+        {
+            // Act
+            _proxy.SynchronousVoidMethod();
+
+            // Assert
+            Assert.Equal(4, _log.Count);
+        }
+
+        [Fact]
+        public void ShouldAllowProcessingPriorToInvocation()
+        {
+            // Act
+            _proxy.SynchronousVoidMethod();
+
+            // Assert
+            Assert.Equal($"{MethodName}:StartingInvocation", _log[0]);
+        }
+
+        [Fact]
+        public void ShouldAllowProcessingAfterInvocation()
+        {
+            // Act
+            _proxy.SynchronousVoidMethod();
+
+            // Assert
+            Assert.Equal($"{MethodName}:CompletedInvocation:(no return value)", _log[3]);
+        }
+    }
+
+    public class WhenProcessingSynchronousResultMethodsWithTheReturnValue
+    {
+        private const string MethodName = nameof(IInterfaceToProxy.SynchronousResultMethod);
+        private readonly List<string> _log = new List<string>();
+        private readonly TestProcessingReturnValueAsyncInterceptor _interceptor;
+        private readonly IInterfaceToProxy _proxy;
+
+        public WhenProcessingSynchronousResultMethodsWithTheReturnValue()
+        {
+            _interceptor = new TestProcessingReturnValueAsyncInterceptor(_log);
+            _proxy = ProxyGen.CreateProxy(_log, _interceptor);
+        }
+
+        [Fact]
+        public void ShouldLog4Entries()
+        {
+            // Act
+            _proxy.SynchronousResultMethod();
+
+            // Assert
+            Assert.Equal(4, _log.Count);
+        }
+
+        [Fact]
+        public void ShouldAllowProcessingPriorToInvocation()
+        {
+            // Act
+            _proxy.SynchronousResultMethod();
+
+            // Assert
+            Assert.Equal($"{MethodName}:StartingInvocation", _log[0]);
+        }
+
+        [Fact]
+        public void ShouldAllowProcessingAfterInvocation()
+        {
+            // Act
+            Guid returnValue = _proxy.SynchronousResultMethod();
+
+            // Assert
+            Assert.Equal($"{MethodName}:CompletedInvocation:{returnValue}", _log[3]);
+        }
+    }
+
+    public class WhenProcessingAsynchronousVoidMethodsWithTheReturnValue
+    {
+        private const string MethodName = nameof(IInterfaceToProxy.AsynchronousVoidMethod);
+        private readonly List<string> _log = new List<string>();
+        private readonly TestProcessingReturnValueAsyncInterceptor _interceptor;
+        private readonly IInterfaceToProxy _proxy;
+
+        public WhenProcessingAsynchronousVoidMethodsWithTheReturnValue()
+        {
+            _interceptor = new TestProcessingReturnValueAsyncInterceptor(_log);
+            _proxy = ProxyGen.CreateProxy(_log, _interceptor);
+        }
+
+        [Fact]
+        public async Task ShouldLog4Entries()
+        {
+            // Act
+            await _proxy.AsynchronousVoidMethod();
+
+            // Assert
+            Assert.Equal(4, _log.Count);
+        }
+
+        [Fact]
+        public async Task ShouldAllowProcessingPriorToInvocation()
+        {
+            // Act
+            await _proxy.AsynchronousVoidMethod();
+
+            // Assert
+            Assert.Equal($"{MethodName}:StartingInvocation", _log[0]);
+        }
+
+        [Fact]
+        public async Task ShouldAllowProcessingAfterInvocation()
+        {
+            // Act
+            await _proxy.AsynchronousVoidMethod();
+
+            // Assert
+            Assert.Equal($"{MethodName}:CompletedInvocation:(no return value)", _log[3]);
+        }
+    }
+
+    public class WhenProcessingAsynchronousResultMethodsWithTheReturnValue
+    {
+        private const string MethodName = nameof(IInterfaceToProxy.AsynchronousResultMethod);
+        private readonly List<string> _log = new List<string>();
+        private readonly TestProcessingReturnValueAsyncInterceptor _interceptor;
+        private readonly IInterfaceToProxy _proxy;
+
+        public WhenProcessingAsynchronousResultMethodsWithTheReturnValue()
+        {
+            _interceptor = new TestProcessingReturnValueAsyncInterceptor(_log);
+            _proxy = ProxyGen.CreateProxy(_log, _interceptor);
+        }
+
+        [Fact]
+        public async Task ShouldLog4Entries()
+        {
+            // Act
+            Guid result = await _proxy.AsynchronousResultMethod();
+
+            // Assert
+            Assert.NotEqual(Guid.Empty, result);
+            Assert.Equal(4, _log.Count);
+        }
+
+        [Fact]
+        public async Task ShouldAllowProcessingPriorToInvocation()
+        {
+            // Act
+            await _proxy.AsynchronousResultMethod();
+
+            // Assert
+            Assert.Equal($"{MethodName}:StartingInvocation", _log[0]);
+        }
+
+        [Fact]
+        public async Task ShouldAllowProcessingAfterInvocation()
+        {
+            // Act
+            Guid returnValue = await _proxy.AsynchronousResultMethod();
+
+            // Assert
+            Assert.Equal($"{MethodName}:CompletedInvocation:{returnValue}", _log[3]);
+        }
+    }
+}

--- a/test/Castle.Core.AsyncInterceptor.Tests/app.config
+++ b/test/Castle.Core.AsyncInterceptor.Tests/app.config
@@ -2,10 +2,6 @@
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-      <dependentAssembly>
-        <assemblyIdentity name="Moq" publicKeyToken="69f491c39445e920" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.7.8.0" newVersion="4.7.8.0" />
-      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>

--- a/test/Castle.Core.AsyncInterceptor.Tests/packages.config
+++ b/test/Castle.Core.AsyncInterceptor.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Castle.Core" version="4.0.0" targetFramework="net461" />
+  <package id="Castle.Core" version="4.1.0" targetFramework="net461" />
   <package id="Moq" version="4.7.8" targetFramework="net461" />
   <package id="OpenCover" version="4.6.519" targetFramework="net461" />
   <package id="ReportGenerator" version="2.5.6" targetFramework="net461" />

--- a/test/Castle.Core.AsyncInterceptor.Tests/packages.config
+++ b/test/Castle.Core.AsyncInterceptor.Tests/packages.config
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Castle.Core" version="4.1.0" targetFramework="net461" />
-  <package id="Moq" version="4.7.8" targetFramework="net461" />
+  <package id="Moq" version="4.7.63" targetFramework="net461" />
   <package id="OpenCover" version="4.6.519" targetFramework="net461" />
-  <package id="ReportGenerator" version="2.5.6" targetFramework="net461" />
+  <package id="ReportGenerator" version="2.5.9" targetFramework="net461" />
   <package id="xunit" version="2.2.0" targetFramework="net461" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net461" />
   <package id="xunit.assert" version="2.2.0" targetFramework="net461" />


### PR DESCRIPTION
This is based on the feedback from #15, where it would be useful to get access to the underlying return value of the invocation, e.g. not the `Task<TResult>` but the `TResult` if there is a value.

The return value of the IInvocation **should** remain a `Task<TResult>` changing it would not be wise, but I'm suggesting an overload to [CompletedInvocation](https://github.com/JSkimming/Castle.Core.AsyncInterceptor/blob/v1.2.3/src/Castle.Core.AsyncInterceptor/ProcessingAsyncInterceptor.cs#L63-L72) that takes the takes the underlying return value, the default implementain being below, for backwards compatability.

```csharp
protected virtual void CompletedInvocation(
    IInvocation invocation,
    TState state, object returnValue)
{
    CompletedInvocation(invocation, state);
}
```

More tests are required, and maybe a similar an overload to [CompletedTiming](https://github.com/JSkimming/Castle.Core.AsyncInterceptor/blob/v1.2.3/src/Castle.Core.AsyncInterceptor/AsyncTimingInterceptor.cs#L47-L53). Though that's harder since it's an abtract method.

Closes #15