### PR TITLE
Test demonstrating Issue #25 - Root Cause: Calls to proceed after the first await are intercepted again

### DIFF
--- a/test/Castle.Core.AsyncInterceptor.Tests/InterfaceProxies/TestAsyncInterceptorBase.cs
+++ b/test/Castle.Core.AsyncInterceptor.Tests/InterfaceProxies/TestAsyncInterceptorBase.cs
@@ -24,6 +24,7 @@ namespace Castle.DynamicProxy.InterfaceProxies
             {
                 _log.Add($"{invocation.Method.Name}:StartingVoidInvocation");
 
+                await Task.Yield();
                 await proceed(invocation).ConfigureAwait(false);
 
                 if (_msDeley > 0)

--- a/test/Castle.Core.AsyncInterceptor.Tests/Issue25MinimumRepro.cs
+++ b/test/Castle.Core.AsyncInterceptor.Tests/Issue25MinimumRepro.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) 2016 James Skimming. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Castle.DynamicProxy
+{
+    public class Issue25MinimumRepro
+    {
+        [Fact]
+        public async Task ShouldNotInterceptIndefinitely()
+        {
+            var interceptor = new Interceptor();
+            ISample sample = new Sample();
+
+            ProxyGenerator proxyGenerator = new ProxyGenerator();
+            ISample proxy = proxyGenerator.CreateInterfaceProxyWithTargetInterface<ISample>(
+                sample,
+                interceptor);
+
+            // Should not throw
+            await proxy.DoAsync();
+        }
+
+        public interface ISample
+        {
+            Task DoAsync();
+        }
+
+        private class Sample : ISample
+        {
+            public Task DoAsync()
+            {
+                return Task.FromResult(0);
+            }
+        }
+        
+        /// <summary>
+        /// A non-reusable interceptor for demonstration of Issue 25.
+        /// The only proper usage is to use a single <see cref="Interceptor"/> ONE time
+        /// to intercept ONE operation on the target interface.
+        /// </summary>
+        private class Interceptor : AsyncInterceptorBase
+        {
+            private int interceptions = 0;
+
+            protected override async Task InterceptAsync(IInvocation invocation, Func<IInvocation, Task> proceed)
+            {
+                if (Interlocked.Increment(ref this.interceptions) > 1)
+                {
+                    throw new InvalidOperationException("InterceptAsync was called more than once");
+                }
+
+                await Task.Yield();
+                await proceed(invocation);
+            }
+
+            protected override Task<TResult> InterceptAsync<TResult>(IInvocation invocation, Func<IInvocation, Task<TResult>> proceed)
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}


### PR DESCRIPTION
Issue #25 

It appears to be related to Castle.Core's `AbstractInvocation`'s synchronous method `Proceed()`.

This method uses a `currentInterceptorIndex` to tell when it's through all of the interceptors, and not utilize interception (instead using `InvokeMethodOnTarget()`). In the async case, this method is not being called twice _nested_ (once to trigger the interceptor, and then again to invoke on the target at `proceed()`), but instead it's being called serially (either creating a new `AbstractInvocation` or it's exiting the `finally` in between the calls, allowing `currentInterceptorIndex` to reset). Therefore, Castle treats the `proceed()` as an interceptable call.