### PR TITLE
Fix issue 25

### DIFF
--- a/src/Castle.Core.AsyncInterceptor/AsyncDeterminationInterceptor.cs
+++ b/src/Castle.Core.AsyncInterceptor/AsyncDeterminationInterceptor.cs
@@ -46,7 +46,6 @@ namespace Castle.DynamicProxy
         /// Intercepts a method <paramref name="invocation"/>.
         /// </summary>
         /// <param name="invocation">The method invocation.</param>
-        [DebuggerStepThrough]
         public virtual void Intercept(IInvocation invocation)
         {
             MethodType methodType = GetMethodType(invocation.Method.ReturnType);

--- a/src/Castle.Core.AsyncInterceptor/AsyncInterceptorBase.cs
+++ b/src/Castle.Core.AsyncInterceptor/AsyncInterceptorBase.cs
@@ -92,15 +92,15 @@ namespace Castle.DynamicProxy
         {
             Task task = me.InterceptAsyncWrapper(invocation, ProceedSynchronous);
 
-            // If the intercept task has yet to complete, wait for it.
-            if (!task.IsCompleted)
+            try
             {
-                Task.Run(() => task).Wait();
+                task.GetAwaiter().GetResult();
             }
-
-            if (task.IsFaulted)
+            catch (AggregateException ae)
             {
-                throw task.Exception.InnerException;
+                // Synchronous method with asynchronous interception... not clear what behavior is expected.
+                // if the method throws, we expect it's exception. but if the interceptor throws, we expect AggregateException (async-style)
+                throw ae.InnerException;
             }
         }
 
@@ -108,15 +108,15 @@ namespace Castle.DynamicProxy
         {
             Task<TResult> task = me.InterceptAsyncWrapper(invocation, ProceedSynchronous<TResult>);
 
-            // If the intercept task has yet to complete, wait for it.
-            if (!task.IsCompleted)
+            try
             {
-                Task.Run(() => task).Wait();
+                task.GetAwaiter().GetResult();
             }
-
-            if (task.IsFaulted)
+            catch (AggregateException ae)
             {
-                throw task.Exception.InnerException;
+                // Synchronous method with asynchronous interception... not clear what behavior is expected.
+                // if the method throws, we expect it's exception. but if the interceptor throws, we expect AggregateException (async-style)
+                throw ae.InnerException;
             }
         }
 

--- a/src/Castle.Core.AsyncInterceptor/AsyncInterceptorBase.cs
+++ b/src/Castle.Core.AsyncInterceptor/AsyncInterceptorBase.cs
@@ -190,8 +190,9 @@ namespace Castle.DynamicProxy
             Task ProceedWrapper(IInvocation innerInvocation)
             {
                 // "until proceed is called"
+                var result = proceed(innerInvocation);
                 canReturnTcs.TrySetResult(null);
-                return proceed(innerInvocation);
+                return result;
             }
 
             // Will block until implementorTask's first await
@@ -213,8 +214,9 @@ namespace Castle.DynamicProxy
             Task<TResult> ProceedWrapper(IInvocation innerInvocation)
             {
                 // "until proceed is called"
+                var result = proceed(innerInvocation);
                 canReturnTcs.TrySetResult(null);
-                return proceed(innerInvocation);
+                return result;
             }
 
             // Will block until implementorTask's first await

--- a/src/Castle.Core.AsyncInterceptor/AsyncInterceptorBase.cs
+++ b/src/Castle.Core.AsyncInterceptor/AsyncInterceptorBase.cs
@@ -187,16 +187,15 @@ namespace Castle.DynamicProxy
         {
             // Do not return from this method until proceed is called or the implementor is finished
             TaskCompletionSource<object> canReturnTcs = new TaskCompletionSource<object>();
-            var newProceed = new Func<IInvocation, Task>(
-                innerInvocation =>
-                {
-                    // "until proceed is called"
-                    canReturnTcs.TrySetResult(null);
-                    return proceed(innerInvocation);
-                });
+            Task ProceedWrapper(IInvocation innerInvocation)
+            {
+                // "until proceed is called"
+                canReturnTcs.TrySetResult(null);
+                return proceed(innerInvocation);
+            }
 
             // Will block until implementorTask's first await
-            var implementorTask = InterceptAsync(invocation, newProceed);
+            Task implementorTask = InterceptAsync(invocation, ProceedWrapper);
 
             // "or the implementor is finished"
             implementorTask.ContinueWith(_ => canReturnTcs.TrySetResult(null));
@@ -205,20 +204,21 @@ namespace Castle.DynamicProxy
             return implementorTask;
         }
 
-        private Task<TResult> InterceptAsyncWrapper<TResult>(IInvocation invocation, Func<IInvocation, Task<TResult>> proceed)
+        private Task<TResult> InterceptAsyncWrapper<TResult>(
+            IInvocation invocation,
+            Func<IInvocation, Task<TResult>> proceed)
         {
             // Do not return from this method until proceed is called or the implementor is finished
             TaskCompletionSource<object> canReturnTcs = new TaskCompletionSource<object>();
-            var newProceed = new Func<IInvocation, Task<TResult>>(
-                innerInvocation =>
-                {
-                    // "until proceed is called"
-                    canReturnTcs.TrySetResult(null);
-                    return proceed(innerInvocation);
-                });
+            Task<TResult> ProceedWrapper(IInvocation innerInvocation)
+            {
+                // "until proceed is called"
+                canReturnTcs.TrySetResult(null);
+                return proceed(innerInvocation);
+            }
 
             // Will block until implementorTask's first await
-            var implementorTask = InterceptAsync(invocation, newProceed);
+            Task<TResult> implementorTask = InterceptAsync(invocation, ProceedWrapper);
 
             // "or the implementor is finished"
             implementorTask.ContinueWith(_ => canReturnTcs.TrySetResult(null));

--- a/src/Castle.Core.AsyncInterceptor/AsyncInterceptorBase.cs
+++ b/src/Castle.Core.AsyncInterceptor/AsyncInterceptorBase.cs
@@ -90,7 +90,7 @@ namespace Castle.DynamicProxy
 
         private static void InterceptSynchronousVoid(AsyncInterceptorBase me, IInvocation invocation)
         {
-            Task task = me.InterceptAsync(invocation, ProceedSynchronous);
+            Task task = me.InterceptAsyncWrapper(invocation, ProceedSynchronous);
 
             // If the intercept task has yet to complete, wait for it.
             if (!task.IsCompleted)
@@ -106,7 +106,7 @@ namespace Castle.DynamicProxy
 
         private static void InterceptSynchronousResult<TResult>(AsyncInterceptorBase me, IInvocation invocation)
         {
-            Task task = me.InterceptAsync(invocation, ProceedSynchronous<TResult>);
+            Task<TResult> task = me.InterceptAsyncWrapper(invocation, ProceedSynchronous<TResult>);
 
             // If the intercept task has yet to complete, wait for it.
             if (!task.IsCompleted)

--- a/test/Castle.Core.AsyncInterceptor.Tests/AsyncExceptionInterceptorShould.cs
+++ b/test/Castle.Core.AsyncInterceptor.Tests/AsyncExceptionInterceptorShould.cs
@@ -18,7 +18,7 @@ namespace Castle.DynamicProxy
 
         protected WhenExceptionInterceptingSynchronousVoidMethodsBase(int msDelay)
         {
-            // The delay is used to simulate work my the interceptor, thereof not always continuing on the same thread.
+            // The delay is used to simulate work by the interceptor, thereof not always continuing on the same thread.
             var interceptor = new TestAsyncInterceptorBase(_log, msDelay);
             _proxy = ProxyGen.CreateProxy(_log, interceptor);
         }
@@ -299,21 +299,21 @@ namespace Castle.DynamicProxy
         }
 
         [Fact]
-        public void ShouldReturnAFaultedTask()
+        public async Task ShouldReturnAFaultedTask()
         {
             // Arrange
             MyClass sut = ProxyGen.Generator.CreateClassProxyWithTarget(new MyClass(), new MyInterceptorBase());
 
             // Act
             Task result = sut.Test1();
-
+            
             // Assert
-            Assert.True(result.IsFaulted);
-            Assert.IsType<ArgumentOutOfRangeException>(result.Exception.InnerException);
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+                () => sut.Test1());
         }
 
         [Fact]
-        public void ShouldReturnAFaultedTaskResult()
+        public async Task ShouldReturnAFaultedTaskResult()
         {
             // Arrange
             MyClass sut = ProxyGen.Generator.CreateClassProxyWithTarget(new MyClass(), new MyInterceptorBase());
@@ -322,8 +322,8 @@ namespace Castle.DynamicProxy
             Task<object> result = sut.Test2();
 
             // Assert
-            Assert.True(result.IsFaulted);
-            Assert.IsType<ArgumentOutOfRangeException>(result.Exception.InnerException);
+            await Assert.ThrowsAsync<ArgumentOutOfRangeException>(
+                () => sut.Test1());
         }
     }
 }

--- a/test/Castle.Core.AsyncInterceptor.Tests/InterfaceProxies/TestAsyncInterceptorBase.cs
+++ b/test/Castle.Core.AsyncInterceptor.Tests/InterfaceProxies/TestAsyncInterceptorBase.cs
@@ -24,6 +24,7 @@ namespace Castle.DynamicProxy.InterfaceProxies
             {
                 _log.Add($"{invocation.Method.Name}:StartingVoidInvocation");
 
+                await Task.Yield();
                 await proceed(invocation).ConfigureAwait(false);
 
                 if (_msDeley > 0)


### PR DESCRIPTION
Fixes #25 

@JSkimming I'm not familiar with .NET Core style projects. I see that the original code has some NETStandard2_0 conditional compilation sections that I think this new code will need similar mechanisms for, but I wasn't able to get the tests targeting that with xUnit to test my changes - perhaps you could help update the change to work with 2.0?

This approach has the problem of having a `.Wait()`, but I believe that since Castle.Core only provides synchronous interception today this may be inevitable - but this doesn't make it any less perilous.

Finally, while coverage will say this is fully covered, it's not functionally fully covered. Probably needs proper tests before check in to mainline - but it does make #26 pass :)