### PR TITLE
possible solution for loop when call await method before invocation.Proceed

### DIFF
--- a/src/Castle.Core.AsyncInterceptor/AsyncInterceptorBase.cs
+++ b/src/Castle.Core.AsyncInterceptor/AsyncInterceptorBase.cs
@@ -50,7 +50,18 @@ namespace Castle.DynamicProxy
         /// <param name="invocation">The method invocation.</param>
         void IAsyncInterceptor.InterceptAsynchronous(IInvocation invocation)
         {
-            invocation.ReturnValue = InterceptAsync(invocation, ProceedAsynchronous);
+            Task task = InterceptAsync(invocation, ProceedAsynchronous);
+
+            // prevent exception propagation
+            try
+            {
+                task.GetAwaiter().GetResult();
+            }
+            catch (Exception)
+            {
+            }
+
+            invocation.ReturnValue = task;
         }
 
         /// <summary>
@@ -60,7 +71,18 @@ namespace Castle.DynamicProxy
         /// <param name="invocation">The method invocation.</param>
         void IAsyncInterceptor.InterceptAsynchronous<TResult>(IInvocation invocation)
         {
-            invocation.ReturnValue = InterceptAsync(invocation, ProceedAsynchronous<TResult>);
+            Task<TResult> task = InterceptAsync(invocation, ProceedAsynchronous<TResult>);
+
+            // prevent exception propagation
+            try
+            {
+                task.GetAwaiter().GetResult();
+            }
+            catch (Exception)
+            {
+            }
+
+            invocation.ReturnValue = task;
         }
 
         /// <summary>

--- a/src/Castle.Core.AsyncInterceptor/AsyncInterceptorBase.cs
+++ b/src/Castle.Core.AsyncInterceptor/AsyncInterceptorBase.cs
@@ -50,7 +50,7 @@ namespace Castle.DynamicProxy
         /// <param name="invocation">The method invocation.</param>
         void IAsyncInterceptor.InterceptAsynchronous(IInvocation invocation)
         {
-            Task task = InterceptAsync(invocation, ProceedAsynchronous);
+            Task task = Task.Factory.StartNew(() => InterceptAsync(invocation, ProceedAsynchronous)).Unwrap();
 
             // prevent exception propagation
             try
@@ -71,7 +71,7 @@ namespace Castle.DynamicProxy
         /// <param name="invocation">The method invocation.</param>
         void IAsyncInterceptor.InterceptAsynchronous<TResult>(IInvocation invocation)
         {
-            Task<TResult> task = InterceptAsync(invocation, ProceedAsynchronous<TResult>);
+            Task<TResult> task = Task.Factory.StartNew(() => InterceptAsync(invocation, ProceedAsynchronous<TResult>)).Unwrap();
 
             // prevent exception propagation
             try

--- a/src/Castle.Core.AsyncInterceptor/ProcessingAsyncInterceptor.cs
+++ b/src/Castle.Core.AsyncInterceptor/ProcessingAsyncInterceptor.cs
@@ -3,6 +3,7 @@
 
 namespace Castle.DynamicProxy
 {
+    using System;
     using System.Threading.Tasks;
 
     /// <summary>
@@ -35,7 +36,19 @@ namespace Castle.DynamicProxy
         public void InterceptAsynchronous(IInvocation invocation)
         {
             TState state = Proceed(invocation);
-            invocation.ReturnValue = SignalWhenComplete(invocation, state);
+
+            Task task = SignalWhenComplete(invocation, state);
+
+            // prevent exception propagation
+            try
+            {
+                task.GetAwaiter().GetResult();
+            }
+            catch (Exception)
+            {
+            }
+
+            invocation.ReturnValue = task;
         }
 
         /// <summary>
@@ -46,7 +59,19 @@ namespace Castle.DynamicProxy
         public void InterceptAsynchronous<TResult>(IInvocation invocation)
         {
             TState state = Proceed(invocation);
-            invocation.ReturnValue = SignalWhenComplete<TResult>(invocation, state);
+
+            Task<TResult> task = SignalWhenComplete<TResult>(invocation, state);
+
+            // prevent exception propagation
+            try
+            {
+                task.GetAwaiter().GetResult();
+            }
+            catch (Exception)
+            {
+            }
+
+            invocation.ReturnValue = task;
         }
 
         /// <summary>

--- a/src/Castle.Core.AsyncInterceptor/ProcessingAsyncInterceptor.cs
+++ b/src/Castle.Core.AsyncInterceptor/ProcessingAsyncInterceptor.cs
@@ -37,7 +37,7 @@ namespace Castle.DynamicProxy
         {
             TState state = Proceed(invocation);
 
-            Task task = SignalWhenComplete(invocation, state);
+            Task task = Task.Factory.StartNew(() => SignalWhenComplete(invocation, state)).Unwrap();
 
             // prevent exception propagation
             try
@@ -60,7 +60,7 @@ namespace Castle.DynamicProxy
         {
             TState state = Proceed(invocation);
 
-            Task<TResult> task = SignalWhenComplete<TResult>(invocation, state);
+            Task<TResult> task = Task.Factory.StartNew(() => SignalWhenComplete<TResult>(invocation, state)).Unwrap();
 
             // prevent exception propagation
             try

--- a/test/Castle.Core.AsyncInterceptor.Tests/AsyncInterceptorShould.cs
+++ b/test/Castle.Core.AsyncInterceptor.Tests/AsyncInterceptorShould.cs
@@ -31,7 +31,7 @@ namespace Castle.DynamicProxy
             // Arrange
             var classWithInterfaceToProxy = new ClassWithInterfaceToProxy(log);
 
-            var proxy = Generator.CreateInterfaceProxyWithTargetInterface<IInterfaceToProxy>(
+            IInterfaceToProxy proxy = Generator.CreateInterfaceProxyWithTargetInterface<IInterfaceToProxy>(
                 classWithInterfaceToProxy,
                 interceptor);
 
@@ -129,10 +129,13 @@ namespace Castle.DynamicProxy
         private const string MethodName = nameof(IInterfaceToProxy.AsynchronousVoidMethod);
         private readonly List<string> _log = new List<string>();
         private readonly IInterfaceToProxy _proxy;
+        private readonly IInterfaceToProxy _proxyWithAwaitBefore;
 
         public WhenInterceptingAsynchronousVoidMethods()
         {
             _proxy = ProxyGen.CreateProxy(_log, new TestAsyncInterceptor(_log));
+            _proxyWithAwaitBefore = ProxyGen.CreateProxy(_log, new TestAsyncInterceptorWithAwaitBefore(_log, 200));
+
         }
 
         [Fact]
@@ -164,6 +167,23 @@ namespace Castle.DynamicProxy
             // Assert
             Assert.Equal($"{MethodName}:InterceptEnd", _log[3]);
         }
+
+
+        [Fact]
+        public async Task ShouldInterceptAsynchronousMethodsWithAnAsyncOperationsPriorToCallingProceed()
+        {
+            await _proxyWithAwaitBefore.AsynchronousVoidMethod().ConfigureAwait(false);
+
+            // Assert
+            // Assert
+            Assert.Equal(5, _log.Count);
+
+            Assert.Equal("AsynchronousVoidMethod:CallAwaitBeforeInvocation", _log[0]);
+            Assert.Equal("AsynchronousVoidMethod:StartingVoidInvocation", _log[1]);
+            Assert.Equal("AsynchronousVoidMethod:Start", _log[2]);
+            Assert.Equal("AsynchronousVoidMethod:End", _log[3]);
+            Assert.Equal("AsynchronousVoidMethod:CompletedVoidInvocation", _log[4]);
+        }
     }
 
     public class WhenInterceptingAsynchronousResultMethods
@@ -171,10 +191,12 @@ namespace Castle.DynamicProxy
         private const string MethodName = nameof(IInterfaceToProxy.AsynchronousResultMethod);
         private readonly List<string> _log = new List<string>();
         private readonly IInterfaceToProxy _proxy;
+        private readonly IInterfaceToProxy _proxyWithAwaitBefore;
 
         public WhenInterceptingAsynchronousResultMethods()
         {
             _proxy = ProxyGen.CreateProxy(_log, new TestAsyncInterceptor(_log));
+            _proxyWithAwaitBefore = ProxyGen.CreateProxy(_log, new TestAsyncInterceptorWithAwaitBefore(_log, 200));
         }
 
         [Fact]
@@ -207,5 +229,25 @@ namespace Castle.DynamicProxy
             // Assert
             Assert.Equal($"{MethodName}:InterceptEnd", _log[3]);
         }
+
+
+
+        [Fact]
+        public async Task ShouldInterceptAsynchronousMethodsWithAnAsyncOperationsPriorToCallingProceed()
+        {
+            await _proxyWithAwaitBefore.AsynchronousVoidMethod().ConfigureAwait(false);
+
+            // Assert
+            Assert.Equal(5, _log.Count);
+
+            Assert.Equal("AsynchronousVoidMethod:CallAwaitBeforeInvocation", _log[0]);
+            Assert.Equal("AsynchronousVoidMethod:StartingVoidInvocation", _log[1]);
+            Assert.Equal("AsynchronousVoidMethod:Start", _log[2]);
+            Assert.Equal("AsynchronousVoidMethod:End", _log[3]);
+            Assert.Equal("AsynchronousVoidMethod:CompletedVoidInvocation", _log[4]);
+
+        }
+
     }
+
 }

--- a/test/Castle.Core.AsyncInterceptor.Tests/Castle.Core.AsyncInterceptor.Tests.csproj
+++ b/test/Castle.Core.AsyncInterceptor.Tests/Castle.Core.AsyncInterceptor.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net47;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
     <RootNamespace>Castle.DynamicProxy</RootNamespace>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>

--- a/test/Castle.Core.AsyncInterceptor.Tests/Castle.Core.AsyncInterceptor.Tests.csproj
+++ b/test/Castle.Core.AsyncInterceptor.Tests/Castle.Core.AsyncInterceptor.Tests.csproj
@@ -1,17 +1,24 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net47;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
     <RootNamespace>Castle.DynamicProxy</RootNamespace>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net45|AnyCPU'">
+    <PlatformTarget>x86</PlatformTarget>
+  </PropertyGroup>
+
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
-    <PackageReference Include="Moq" Version="4.7.145" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.analyzers" Version="0.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="Moq" Version="4.10.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.analyzers" Version="0.10.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0" />
   </ItemGroup>
 

--- a/test/Castle.Core.AsyncInterceptor.Tests/InterfaceProxies/ClassWithInterfaceToProxy.cs
+++ b/test/Castle.Core.AsyncInterceptor.Tests/InterfaceProxies/ClassWithInterfaceToProxy.cs
@@ -76,5 +76,6 @@ namespace Castle.DynamicProxy.InterfaceProxies
             await Task.Delay(10).ConfigureAwait(false);
             throw new InvalidOperationException(nameof(AsynchronousResultExceptionMethod) + ":Exception");
         }
+
     }
 }

--- a/test/Castle.Core.AsyncInterceptor.Tests/InterfaceProxies/TestAsyncInterceptorWithAwaitBefore.cs
+++ b/test/Castle.Core.AsyncInterceptor.Tests/InterfaceProxies/TestAsyncInterceptorWithAwaitBefore.cs
@@ -1,0 +1,66 @@
+﻿// Copyright (c) 2016 James Skimming. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace Castle.DynamicProxy.InterfaceProxies
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    public class TestAsyncInterceptorWithAwaitBefore : AsyncInterceptorBase
+    {
+        private readonly int _msDeley;
+        private readonly ICollection<string> _log;
+
+        public TestAsyncInterceptorWithAwaitBefore(List<string> log, int msDeley)
+        {
+            _log = log ?? throw new ArgumentNullException(nameof(log));
+            _msDeley = msDeley;
+        }
+
+        protected override async Task InterceptAsync(IInvocation invocation, Func<IInvocation, Task> proceed)
+        {
+            try
+            {
+                _log.Add($"{invocation.Method.Name}:CallAwaitBeforeInvocation");
+
+                await Task.Delay(_msDeley);
+
+                _log.Add($"{invocation.Method.Name}:StartingVoidInvocation");
+
+                await proceed(invocation).ConfigureAwait(false);
+
+                _log.Add($"{invocation.Method.Name}:CompletedVoidInvocation");
+            }
+            catch (Exception e)
+            {
+                _log.Add($"{invocation.Method.Name}:VoidExceptionThrown:{e.Message}");
+                throw;
+            }
+        }
+
+        protected override async Task<TResult> InterceptAsync<TResult>(
+            IInvocation invocation,
+            Func<IInvocation, Task<TResult>> proceed)
+        {
+            try
+            {
+                _log.Add($"{invocation.Method.Name}:CallAwaitBeforeInvocation");
+
+                await Task.Delay(_msDeley);
+
+                _log.Add($"{invocation.Method.Name}:StartingResultInvocation");
+
+                TResult result = await proceed(invocation).ConfigureAwait(false);
+
+                _log.Add($"{invocation.Method.Name}:CompletedResultInvocation");
+                return result;
+            }
+            catch (Exception e)
+            {
+                _log.Add($"{invocation.Method.Name}:ResultExceptionThrown:{e.Message}");
+                throw;
+            }
+        }
+    }
+}

--- a/test/Castle.Core.AsyncInterceptor.Tests/InterfaceProxies/TestAsyncInterceptorWithAwaitBefore.cs
+++ b/test/Castle.Core.AsyncInterceptor.Tests/InterfaceProxies/TestAsyncInterceptorWithAwaitBefore.cs
@@ -9,6 +9,7 @@ namespace Castle.DynamicProxy.InterfaceProxies
 
     public class TestAsyncInterceptorWithAwaitBefore : AsyncInterceptorBase
     {
+
         private readonly int _msDeley;
         private readonly ICollection<string> _log;
 
@@ -25,6 +26,13 @@ namespace Castle.DynamicProxy.InterfaceProxies
                 _log.Add($"{invocation.Method.Name}:CallAwaitBeforeInvocation");
 
                 await Task.Delay(_msDeley);
+
+#if !NETSTANDARD2_0
+                await Task.FromResult(0);
+#else 
+                await Task.CompletedTask;
+#endif
+
 
                 _log.Add($"{invocation.Method.Name}:StartingVoidInvocation");
 
@@ -48,6 +56,12 @@ namespace Castle.DynamicProxy.InterfaceProxies
                 _log.Add($"{invocation.Method.Name}:CallAwaitBeforeInvocation");
 
                 await Task.Delay(_msDeley);
+
+#if !NETSTANDARD2_0
+                await Task.FromResult(0);
+#else 
+                await Task.CompletedTask;
+#endif
 
                 _log.Add($"{invocation.Method.Name}:StartingResultInvocation");
 


### PR DESCRIPTION
In order to test this feature i added  2 new test case
(ShouldInterceptAsynchronousMethodsWithAnAsyncOperationsPriorToCallingProceed)
in AsyncInterceptorShould.cs file

I Created a new TestAsyncInterceptorWithAwaitBefore for the 2 new test cases.

I link the issues involved:
https://github.com/JSkimming/Castle.Core.AsyncInterceptor/issues/49
https://github.com/castleproject/Core/issues/145