### PR TITLE
Convert internal field to public property to allow external access.

### DIFF
--- a/src/Castle.Core.AsyncInterceptor/AsyncDeterminationInterceptor.cs
+++ b/src/Castle.Core.AsyncInterceptor/AsyncDeterminationInterceptor.cs
@@ -23,14 +23,12 @@ namespace Castle.DynamicProxy
         private static readonly ConcurrentDictionary<Type, GenericAsyncHandler> GenericAsyncHandlers =
             new ConcurrentDictionary<Type, GenericAsyncHandler>();
 
-        private readonly IAsyncInterceptor _asyncInterceptor;
-
         /// <summary>
         /// Initializes a new instance of the <see cref="AsyncDeterminationInterceptor"/> class.
         /// </summary>
         public AsyncDeterminationInterceptor(IAsyncInterceptor asyncInterceptor)
         {
-            _asyncInterceptor = asyncInterceptor;
+            AsyncInterceptor = asyncInterceptor;
         }
 
         private delegate void GenericAsyncHandler(IInvocation invocation, IAsyncInterceptor asyncInterceptor);
@@ -41,6 +39,11 @@ namespace Castle.DynamicProxy
             AsyncAction,
             AsyncFunction,
         }
+
+        /// <summary>
+        /// Gets the underlying async interceptor
+        /// </summary>
+        public IAsyncInterceptor AsyncInterceptor { get; }
 
         /// <summary>
         /// Intercepts a method <paramref name="invocation"/>.
@@ -54,13 +57,13 @@ namespace Castle.DynamicProxy
             switch (methodType)
             {
                 case MethodType.AsyncAction:
-                    _asyncInterceptor.InterceptAsynchronous(invocation);
+                    AsyncInterceptor.InterceptAsynchronous(invocation);
                     return;
                 case MethodType.AsyncFunction:
-                    GetHandler(invocation.Method.ReturnType).Invoke(invocation, _asyncInterceptor);
+                    GetHandler(invocation.Method.ReturnType).Invoke(invocation, AsyncInterceptor);
                     return;
                 default:
-                    _asyncInterceptor.InterceptSynchronous(invocation);
+                    AsyncInterceptor.InterceptSynchronous(invocation);
                     return;
             }
         }


### PR DESCRIPTION
First off - Thanks for this incredible library!!  I just came across it recently.  Here's the problem that I am facing and reason for this PR:

I am using the `IInterceptorSelector` interface to filter the interceptors for specific methods.  I am also using the `IAsyncInterceptor` interface (through the `AsyncInterceptorBase` class).  

When the `IInterceptorSelector.SelectInterceptors()` method is called, if I inspect the interceptors parameter, instead of seeing my specific implementation of an `IAsyncInterceptor` I see an `AsyncDeterminationInterceptor`.  This isn't necessarily an issue but my filter criteria depends on me being able to see if one of the interceptors is my specific `IAsyncInterceptor` implementation.  As it stands now, I don't see a way of determining what the underlying interceptor is that is being used by the `AsyncDeterminationInterceptor` instance.

This PR simply exposes the previously `Private` field as a `Public` property now so that I can inspect the underlying `IAsyncInterceptor`.