### PR TITLE
Remove type constraint for interface target

### DIFF
--- a/src/Castle.Core.AsyncInterceptor/ProxyGeneratorExtensions.cs
+++ b/src/Castle.Core.AsyncInterceptor/ProxyGeneratorExtensions.cs
@@ -147,7 +147,6 @@ namespace Castle.DynamicProxy
             this IProxyGenerator proxyGenerator,
             TInterface target,
             params IAsyncInterceptor[] interceptors)
-            where TInterface : class
         {
             return proxyGenerator.CreateInterfaceProxyWithTargetInterface(target, interceptors.ToInterceptors());
         }
@@ -160,7 +159,6 @@ namespace Castle.DynamicProxy
             TInterface target,
             ProxyGenerationOptions options,
             params IAsyncInterceptor[] interceptors)
-            where TInterface : class
         {
             return proxyGenerator.CreateInterfaceProxyWithTargetInterface(
                 target,


### PR DESCRIPTION
I think having a class type constraint when the name of a method is interface target just does not make sense.