### PR TITLE
Remove the netstandard1.4 build target

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,27 +32,6 @@ orbs:
           - store_test_results:
               path: ./test/TestResults/output/
 
-      # The --no-restore parameter was added in .NET Core 2, so add a dedicated job for building .NET Core 1.1
-      run-build-1-1:
-        parameters:
-          build-config:
-            description: The build configuration, either Debug or Release.
-            type: string
-        executor:
-          name: dotnet-build-executor
-          tag: "1.1"
-        steps:
-          - checkout
-          - run:
-              name: Restore
-              command: dotnet restore
-          - run:
-              name: Build
-              command: dotnet build -f netcoreapp1.1 -c << parameters.build-config >> ./test/Castle.Core.AsyncInterceptor.Tests/Castle.Core.AsyncInterceptor.Tests.csproj
-          - run:
-              name: Test
-              command: dotnet test --no-build -f netcoreapp1.1 -c << parameters.build-config >> ./test/Castle.Core.AsyncInterceptor.Tests/Castle.Core.AsyncInterceptor.Tests.csproj
-
     executors:
 
       dotnet-build-executor:
@@ -69,12 +48,6 @@ workflows:
     jobs:
       - shellcheck/check:
           name: shellcheck
-      - build/run-build-1-1:
-          name: 1.1 Debug Build
-          build-config: Debug
-      - build/run-build-1-1:
-          name: 1.1 Release Build
-          build-config: Release
       - build/run-build:
           name: 2.1 Debug Build
           image-tag: "2.1"

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,30 +11,6 @@ RUN find . -type f -name '*.sh' -exec dos2unix {} \;
 RUN find . -type f -name '*.sh' | wc -l && find . -type f -name '*.sh' | xargs shellcheck --external-sources
 
 ########################################################################################################################
-# .NET Core 1.1
-FROM mcr.microsoft.com/dotnet/core/sdk:1.1
-
-ENV DOTNET_SKIP_FIRST_TIME_EXPERIENCE=true
-
-WORKDIR /work
-
-# Copy just the solution and proj files to make best use of docker image caching.
-COPY ./castle.core.asyncinterceptor.sln .
-COPY ./src/Castle.Core.AsyncInterceptor/Castle.Core.AsyncInterceptor.csproj ./src/Castle.Core.AsyncInterceptor/Castle.Core.AsyncInterceptor.csproj
-COPY ./test/Castle.Core.AsyncInterceptor.Tests/Castle.Core.AsyncInterceptor.Tests.csproj ./test/Castle.Core.AsyncInterceptor.Tests/Castle.Core.AsyncInterceptor.Tests.csproj
-
-# Run restore on just the project files, this should cache the image after restore.
-RUN dotnet restore
-
-COPY . .
-
-# Build to ensure the tests are their own distinct step
-RUN dotnet build -f netcoreapp1.1 -c Debug ./test/Castle.Core.AsyncInterceptor.Tests/Castle.Core.AsyncInterceptor.Tests.csproj
-
-# Run unit tests
-RUN dotnet test --no-build -f netcoreapp1.1 -c Debug ./test/Castle.Core.AsyncInterceptor.Tests/Castle.Core.AsyncInterceptor.Tests.csproj
-
-########################################################################################################################
 # .NET Core 2.1
 FROM mcr.microsoft.com/dotnet/core/sdk:2.1-alpine
 

--- a/src/Castle.Core.AsyncInterceptor/Castle.Core.AsyncInterceptor.csproj
+++ b/src/Castle.Core.AsyncInterceptor/Castle.Core.AsyncInterceptor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard1.4;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
     <RootNamespace>Castle.DynamicProxy</RootNamespace>
     <LangVersion>latest</LangVersion>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/test/Castle.Core.AsyncInterceptor.Tests/Castle.Core.AsyncInterceptor.Tests.csproj
+++ b/test/Castle.Core.AsyncInterceptor.Tests/Castle.Core.AsyncInterceptor.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp1.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp2.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <RootNamespace>Castle.DynamicProxy</RootNamespace>
     <IsPackable>false</IsPackable>


### PR DESCRIPTION
It will become increasingly difficult to maintain since the tests can no longer target netcoreapp1.1 since microsoft/vstest#2067.