### PR TITLE
No longer need to exclude SA0001

### DIFF
--- a/test/Castle.Core.AsyncInterceptor.Tests/Castle.Core.AsyncInterceptor.Tests.csproj
+++ b/test/Castle.Core.AsyncInterceptor.Tests/Castle.Core.AsyncInterceptor.Tests.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net472;netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>false</IsPackable>
-    <NoWarn>$(NoWarn);SA0001;CS1591</NoWarn>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Thanks for the [heads-up](https://github.com/JSkimming/Castle.Core.AsyncInterceptor/commit/db5656e8e287ddae4fcb276b6cdac7a27b0cbdc7#r124475634 "💡 SA0001 can be removed from this list now (it was a warning saying to set GenerateDocumentationFile to true, which it now is)") @sharwell